### PR TITLE
Provide support to verify QRL address on Ledger Nano S

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ include $(BOLOS_SDK)/Makefile.defines
 APPNAME = "QRL"
 APPVERSION_M=0
 APPVERSION_N=9
-APPVERSION_P=0
+APPVERSION_P=1
 
 APP_LOAD_PARAMS = --appFlags 0x00 --delete $(COMMON_LOAD_PARAMS) --path "44'/238'"
 ICONNAME=$(CURDIR)/icon.gif

--- a/pkgdemo.sh
+++ b/pkgdemo.sh
@@ -23,7 +23,7 @@ APPNAME=$1
 APPVERSION=$2
 ICONNAME=$3
 
-TARGET_ID=0x31100003
+TARGET_ID=0x31100004
 DATASIZE=$(cat ${SCRIPT_DIR}/debug/app.map |grep _nvram_data_size | tr -s ' ' | cut -f2 -d' ')
 ICONHEX=$(python ${BOLOS_SDK}/icon.py ${ICONNAME} hexbitmaponly)
 

--- a/src/app_main.h
+++ b/src/app_main.h
@@ -33,6 +33,7 @@ extern app_ctx_t ctx;
 #define INS_SIGN                0x04u
 #define INS_SIGN_NEXT           0x05u
 #define INS_SETIDX              0x06u
+#define INS_VIEW_ADDRESS        0x07u
 
 #define INS_TEST_PK_GEN_1       0x80
 #define INS_TEST_PK_GEN_2       0x81

--- a/src/view.h
+++ b/src/view.h
@@ -38,6 +38,7 @@ void view_main_menu(void);
 void view_sign_menu(void);
 void view_txinfo_show();
 void view_setidx_show();
+void view_address_show();
 
 void view_update_state(uint16_t interval);
 


### PR DESCRIPTION
Prior to this change you had to trust the QRL Wallet displayed the correct QRL address for receiving QRL to. This provides a simple UI and INS code to allow verification on the Ledger device itself.